### PR TITLE
Disable deep watcher on $props

### DIFF
--- a/src/components/Moveable.vue
+++ b/src/components/Moveable.vue
@@ -74,7 +74,6 @@ export default {
           this.moveable[key] = newOptions[key];
         });
       },
-      deep: true,
     },
   },
   beforeDestroy() {

--- a/src/components/Moveable.vue
+++ b/src/components/Moveable.vue
@@ -28,6 +28,35 @@ const ALLOWED_EVENTS = [
   'pinchEnd',
 ];
 
+const MOVEABLE_PROPS = [
+  'draggable',
+  'keepRatio',
+  'origin',
+  'pinchable',
+  'resizable',
+  'rotatable',
+  'scalable',
+  'throttleDrag',
+  'throttleResize',
+  'throttleScale',
+  'throttleRotate',
+  'warpable',
+];
+
+const watchReactiveProp = (key, deep) => ({
+  handler(newValue) {
+    const existingValue = this.moveable[key];
+    if (existingValue === newValue) return;
+    this.moveable[key] = newValue;
+  },
+  deep,
+});
+
+const watchMoveableProps = () => MOVEABLE_PROPS.reduce((acc, prop) => {
+  acc[prop] = watchReactiveProp(prop, true);
+  return acc;
+}, {});
+
 export default {
   name: 'Moveable',
   inheritAttrs: false,
@@ -65,16 +94,7 @@ export default {
     window.addEventListener('resize', this.updateRec, { passive: true });
   },
   watch: {
-    $props: {
-      handler(newOptions) {
-        Object.keys(newOptions).forEach((key) => {
-          const existingValue = this.moveable[key];
-          const newValue = newOptions[key];
-          if (existingValue === newValue) return;
-          this.moveable[key] = newOptions[key];
-        });
-      },
-    },
+    ...watchMoveableProps(),
   },
   beforeDestroy() {
     ALLOWED_EVENTS.forEach(event => (


### PR DESCRIPTION
Fixes #27.

This PR tries to mitigate issue by dropping `deep: true` from watcher and provides another way to handle props updates to be passed correctly to `Moveable` instance.