### PR TITLE
Add missing className prop for control box

### DIFF
--- a/src/components/Moveable.vue
+++ b/src/components/Moveable.vue
@@ -121,6 +121,7 @@ export default {
     snappable: [Boolean, Array],
     ables: Array,
     origin: Boolean,
+    className: String,
     container: {
       type: [HTMLElement, SVGElement],
       default: () => document.body,


### PR DESCRIPTION
The `className` is missing in the props (cannot set a custom class name for the control box). 
Added the missing field. 