### PR TITLE
Fix index.d.ts being not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "git+https://github.com/probil/vue-moveable.git"
   },
   "files": [
-    "dist/lib"
+    "dist/lib",
+    "index.d.ts"
   ],
   "author": "Max Lyashuk <m_lyashuk@ukr.net>",
   "license": "MIT",


### PR DESCRIPTION
I'm using vue-moveable-1.6.0.
This PR fixes `package.json` and let a package manager include the type declaration file into a package.

I found `index.d.ts` is not installed under the `node_modules/vue-moveable/` directory after TypeScript complained as follows:
```
Could not find a declaration file for module 'vue-moveable'. '/path/to/my/project/node_modules/vue-moveable/dist/lib/VueMoveable.common.js' implicitly has an 'any' type.
Try `npm install @types/vue-moveable` if it exists or add a new declaration (.d.ts) file containing `declare module 'vue-moveable';`
```

I tested this PR with the following procedure:
```sh
$ cd /path/to/vue-moveable
$ yarn pack
yarn pack v1.22.4
success Wrote tarball to "/path/to/vue-moveable/vue-moveable-v1.6.0.tgz".
Done in 0.07s.
$ tar tf vue-moveable-v1.6.0.tgz
package
package/LICENSE
package/README.md
package/dist
package/index.d.ts
package/package.json
package/dist/lib
package/dist/lib/VueMoveable.common.js
package/dist/lib/VueMoveable.umd.js
package/dist/lib/VueMoveable.umd.min.js
$ cd /my/another/project
$ yarn add /path/to/vue-moveable/vue-moveable-v1.6.0.tgz
$ ls node_modules/vue-moveable
dist  index.d.ts  LICENSE  package.json  README.md
```

Thank you for developing this component!